### PR TITLE
Don't paint the lines when you don't have a device

### DIFF
--- a/src/pymmcore_openscan/widgets/spc_rate_graph.py
+++ b/src/pymmcore_openscan/widgets/spc_rate_graph.py
@@ -1,7 +1,7 @@
 from math import log10
 from typing import Any, cast
 
-from pymmcore_plus import CMMCorePlus, DeviceProperty
+from pymmcore_plus import CMMCorePlus, Device, DeviceProperty
 from qtpy.QtCore import QPointF, QRectF, Qt, QTimer
 from qtpy.QtGui import QColor, QPainter, QPaintEvent, QPalette, QPen
 from qtpy.QtWidgets import (
@@ -73,18 +73,19 @@ class SPCRateGraphCanvas(QWidget):
 
         self._values: dict[DeviceProperty, list[float]] = {}
 
+        self._dev: Device | None = None
         self._try_enable(self._mmcore)
 
     def _try_enable(self, mmcore: CMMCorePlus) -> None:
-        self._prop = None
+        self._dev = None
         self._values.clear()
 
         if "OSc-LSM" in mmcore.getLoadedDevices():
-            dev = mmcore.getDeviceObject("OSc-LSM")
+            self._dev = mmcore.getDeviceObject("OSc-LSM")
             for rate in RATES:
                 name = f"BH-TCSPC-RateCounter-{rate}"
-                if name in dev.propertyNames():
-                    self._values[dev.getPropertyObject(name)] = []
+                if name in self._dev.propertyNames():
+                    self._values[self._dev.getPropertyObject(name)] = []
 
     def paintEvent(self, event: QPaintEvent) -> None:
         """Paint the graph."""
@@ -137,6 +138,9 @@ class SPCRateGraphCanvas(QWidget):
                 label,
             )
 
+        if self._dev is None:
+            # Don't paint anything more if we don't have a device loaded
+            return
         for i in range(len(RATES)):
             color = COLORS[i]
             prop = list(self._values.keys())[i]


### PR DESCRIPTION
This PR cleans up the structure of the `SPCRateGraphCanvas`, such that we return early from the `paintEvent` if there is no device loaded. Now, when you don't have a device loaded, the rate widget looks like this:

<img width="1228" height="1304" alt="image" src="https://github.com/user-attachments/assets/8b7b7eff-c629-4db3-b451-a4e5b1ef3e43" />

This changeset is likely an alternative to #13 for solving #12, unless that PR solves another issue that I have not yet seen. I prefer this approach because it's clear within the code that we're avoiding painting things that you'd need a device to paint.

My question to @JenuC (which we might want to address with a separate PR) - can we better visualize the fact that you don't have the necessary device loaded? What might you like to see as a user? (EDIT: We should probably also consider this question for the other widgets in this package)